### PR TITLE
ci: automate cross-platform release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,125 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build macOS release
+        run: npm run build:mac
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-release
+          path: |
+            dist/*.dmg
+            dist/*.dmg.blockmap
+
+  build-win:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Windows release
+        run: npm run build:win
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-release
+          path: |
+            dist/*.exe
+            dist/*.exe.blockmap
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Linux release
+        run: npm run build:linux
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release
+          path: |
+            dist/*.AppImage
+            dist/*.AppImage.blockmap
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - build-mac
+      - build-win
+      - build-linux
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Generate release notes from tag message
+        shell: bash
+        run: |
+          notes="$(git for-each-ref "refs/tags/${GITHUB_REF_NAME}" --format='%(contents)')"
+          if [ -z "$notes" ]; then
+            notes="Release ${GITHUB_REF_NAME}"
+          fi
+          printf '%s\n' "$notes" > release-notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          files: |
+            release-artifacts/**/*.dmg
+            release-artifacts/**/*.dmg.blockmap
+            release-artifacts/**/*.exe
+            release-artifacts/**/*.exe.blockmap
+            release-artifacts/**/*.AppImage
+            release-artifacts/**/*.AppImage.blockmap

--- a/package.json
+++ b/package.json
@@ -5,16 +5,49 @@
   "main": "src/main.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder --mac"
+    "build": "electron-builder --publish never",
+    "build:mac": "npm run build -- --mac dmg --universal",
+    "build:win": "npm run build -- --win nsis --x64",
+    "build:linux": "npm run build -- --linux AppImage --x64"
   },
   "devDependencies": {
     "electron": "^28.0.0",
     "electron-builder": "^24.0.0"
   },
   "build": {
-    "appId": "com.mboxviewer.app",
+    "appId": "com.mailark.app",
+    "productName": "mailark",
+    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "universal"
+          ]
+        }
+      ],
       "category": "public.app-category.productivity"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## 概要

`main` へのマージ後に `tagpr` がリリース PR とタグ作成を管理し、作成された `v*` タグをトリガーに GitHub Actions で macOS / Windows / Linux 向けのリリースバイナリを自動ビルドして GitHub Release に添付する構成を追加しました。

リリースフローを `tagpr` と build workflow に分離することで、バージョニングとタグ作成は `tagpr`、クロスプラットフォームの成果物生成と Release 公開は既存 release workflow が担う形にしています。

Closes #6

## 変更内容

- `.github/workflows/release.yml` を追加
- `v*` タグ push 時に発火する release workflow を実装
- macOS / Windows / Linux 向けの個別ビルド job を追加
- `actions/upload-artifact` で各成果物を保持
- `softprops/action-gh-release` で GitHub Release を自動作成
- `.github/workflows/tagpr.yml` を追加
- `.tagpr` を追加し、`tagpr` 側の GitHub Release 作成は無効化
- `package.json` の `build` 設定を各プラットフォーム向けに拡張
- `build:mac` / `build:win` / `build:linux` スクリプトを追加
- README に release 運用手順と `RELEASE_PAT` secret の前提を追記

## 確認内容

- `package.json` の JSON 構文確認
- `.github/workflows/release.yml` の YAML 構文確認
- `.github/workflows/tagpr.yml` の YAML 構文確認
- `npm run build -- --help` で `electron-builder` 実行確認
- `npx electron-builder --mac --universal --dir --publish never` で設定読込を確認

## 補足

- `tagpr` が作成したタグで後続 workflow を確実に発火させるため、repository secret `RELEASE_PAT` が必要です
- `Settings > Actions > General` の `Allow GitHub Actions to create and approve pull requests` を有効化してください
- macOS / Windows の codesign は今回は未対応です
- ローカルでの実パッケージングは Electron バイナリ取得時にネットワーク制限で停止したため、完全実行までは確認していません
