### PR TITLE
ci: add tagpr-based release tagging

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,23 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,1 @@
+release: false

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ npm start
 PRはいつでも歓迎です。大きな変更は先にissueを立ててください。  
 PRs welcome. Please open an issue first for large changes.
 
+## リリース / Release
+
+`main` にマージされると `tagpr` がリリース PR とタグ作成を管理し、`v*` タグが作成されると GitHub Actions の release workflow が macOS / Windows / Linux 向けビルドを実行します。
+
+運用前に以下を設定してください。
+
+- `Settings > Actions > General` で `Allow GitHub Actions to create and approve pull requests` を有効化
+- repository secret `RELEASE_PAT` を追加
+
+`RELEASE_PAT` は `tagpr` が作成したタグで後続の release workflow を確実に発火させるために使います。
+
 ## ライセンス / License
 
 MIT


### PR DESCRIPTION
## 概要

`main` へのマージ後に `tagpr` がリリース PR とタグ作成を管理し、作成された `v*` タグをトリガーに既存の release workflow が macOS / Windows / Linux 向けビルドを実行する構成を追加します。

## 変更内容

- `.github/workflows/tagpr.yml` を追加
- `.tagpr` を追加し、`tagpr` 側の GitHub Release 作成は無効化
- README に release 運用手順と `RELEASE_PAT` secret の前提を追記

## 補足

- repository secret `RELEASE_PAT` が必要です
- `Settings > Actions > General` の `Allow GitHub Actions to create and approve pull requests` を有効化してください