### PR TITLE
fix: include compiled app files in release package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "appId": "com.mailark.app",
     "productName": "mailark",
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "files": [
+      "dist/**/*",
+      "src/index.html"
+    ],
     "mac": {
       "target": [
         {


### PR DESCRIPTION
## 概要

release build で `.dmg` / `.exe` / `.AppImage` が出ず、GitHub Release に source archive の zip しか見えない問題を修正します。

原因は `electron-builder` が app.asar 内で `dist/main.js` を見つけられず、パッケージングが失敗していたことです。`.gitignore` により `dist/` が梱包対象から落ちやすい状態だったため、`build.files` を明示して `dist/**/*` と `src/index.html` を含めます。

## 変更内容

- `package.json` の `build.files` に `dist/**/*` を追加
- `package.json` の `build.files` に `src/index.html` を追加

## 補足

- これで `dist/main.js` が app.asar に含まれ、各プラットフォーム成果物の生成に進める想定です
- いま GitHub Release に見えている zip は source archive で、アプリ成果物ではありません