### PR TITLE
fix: separate release output from compiled app files

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -50,8 +50,8 @@ jobs:
         with:
           name: mac-release
           path: |
-            dist/*.dmg
-            dist/*.dmg.blockmap
+            release/*.dmg
+            release/*.dmg.blockmap
 
   build-win:
     runs-on: windows-latest
@@ -78,8 +78,8 @@ jobs:
         with:
           name: win-release
           path: |
-            dist/*.exe
-            dist/*.exe.blockmap
+            release/*.exe
+            release/*.exe.blockmap
 
   build-linux:
     runs-on: ubuntu-latest
@@ -106,8 +106,8 @@ jobs:
         with:
           name: linux-release
           path: |
-            dist/*.AppImage
-            dist/*.AppImage.blockmap
+            release/*.AppImage
+            release/*.AppImage.blockmap
 
   release:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "appId": "com.mailark.app",
     "productName": "mailark",
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "directories": {
+      "output": "release"
+    },
     "files": [
       "dist/**/*",
       "src/index.html"


### PR DESCRIPTION
## 概要

macOS universal build で `.dmg` が生成されず、結果として release asset が空になる問題を修正します。

原因は `build.files` に `dist/**/*` を指定した状態で、electron-builder の出力先も `dist/` のままだったことです。これにより build output 自体を再帰的に app に含めてしまい、macOS universal packaging が `dist/mac-universal-x64-temp/LICENSE` などの差分を検出して失敗していました。

## 変更内容

- `package.json` の `build.directories.output` を `release` に変更
- Actions の artifact upload 対象を `dist/*` から `release/*` に変更

## 効果

- app の入力ファイルは `dist/`
- electron-builder の生成物は `release/`

に分離され、`.dmg` / `.exe` / `.AppImage` を正しく作成できる構成になります。