### PR TITLE
#3 feat: PST to mbox converter using pst-extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "mbox-viewer",
+  "name": "mailark",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mbox-viewer",
+      "name": "mailark",
       "version": "1.0.0",
       "dependencies": {
+        "pst-extractor": "^1.12.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -6478,6 +6479,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -7109,6 +7116,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/pst-extractor": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/pst-extractor/-/pst-extractor-1.12.0.tgz",
+      "integrity": "sha512-mO87iT2FGXc3MZVQ8YVIHn8GghM3WI8Dvqn872JEYXo0Bi5EFewS6hlmdPTasfFzrAJgJgnuA8EXSYSxIrCcyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.7.1",
+        "long": "^5.3.2",
+        "uuid-parse": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pst-extractor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7341,7 +7378,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -8133,6 +8169,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     }
   },
   "dependencies": {
+    "pst-extractor": "^1.12.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/src/__tests__/pstConverter.test.ts
+++ b/src/__tests__/pstConverter.test.ts
@@ -1,0 +1,85 @@
+import { buildMboxEntry, formatMboxDate } from '../converter/pst';
+
+// ─── formatMboxDate ──────────────────────────────────────────────────────────
+
+describe('formatMboxDate', () => {
+  test('Dateオブジェクトをmbox From行の日付形式に変換できる', () => {
+    // mbox From行の日付: "Wed Jan 01 00:00:00 2020" 形式
+    const d = new Date('2020-01-01T00:00:00.000Z');
+    const result = formatMboxDate(d);
+    expect(result).toMatch(/^\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \d{4}$/);
+  });
+
+  test('nullはUnix epochのフォールバック日付を返す', () => {
+    const result = formatMboxDate(null);
+    expect(result).toBeTruthy();
+  });
+});
+
+// ─── buildMboxEntry ──────────────────────────────────────────────────────────
+
+// PSTMessageの最低限のモック型
+interface MockMessage {
+  transportMessageHeaders: string;
+  senderEmailAddress: string;
+  clientSubmitTime: Date | null;
+  subject: string;
+  body: string;
+  bodyHTML: string;
+  displayTo: string;
+}
+
+describe('buildMboxEntry', () => {
+  const baseMessage: MockMessage = {
+    transportMessageHeaders: '',
+    senderEmailAddress: 'sender@example.com',
+    clientSubmitTime: new Date('2022-06-15T09:00:00.000Z'),
+    subject: 'Test Subject',
+    body: 'Hello, World!',
+    bodyHTML: '',
+    displayTo: 'recipient@example.com',
+  };
+
+  test('From行で始まるmboxエントリを生成できる', () => {
+    const result = buildMboxEntry(baseMessage as any);
+    expect(result).toMatch(/^From sender@example\.com /);
+  });
+
+  test('本文が含まれる', () => {
+    const result = buildMboxEntry(baseMessage as any);
+    expect(result).toContain('Hello, World!');
+  });
+
+  test('transportMessageHeadersがある場合はそれをヘッダーとして使う', () => {
+    const msg = {
+      ...baseMessage,
+      transportMessageHeaders: 'From: sender@example.com\r\nSubject: Original\r\n',
+    };
+    const result = buildMboxEntry(msg as any);
+    expect(result).toContain('Subject: Original');
+  });
+
+  test('transportMessageHeadersがない場合は合成ヘッダーを使う', () => {
+    const result = buildMboxEntry(baseMessage as any);
+    expect(result).toContain('From: sender@example.com');
+    expect(result).toContain('Subject: Test Subject');
+    expect(result).toContain('To: recipient@example.com');
+  });
+
+  test('本文中の"From "行をmboxエスケープ(">From ")する', () => {
+    const msg = { ...baseMessage, body: 'From me with love\nNormal line' };
+    const result = buildMboxEntry(msg as any);
+    expect(result).toContain('>From me with love');
+  });
+
+  test('エントリは空行で終わる', () => {
+    const result = buildMboxEntry(baseMessage as any);
+    expect(result.endsWith('\n\n')).toBe(true);
+  });
+
+  test('bodyが空でhtmlBodyがある場合はHTML本文を使う', () => {
+    const msg = { ...baseMessage, body: '', bodyHTML: '<p>HTML content</p>' };
+    const result = buildMboxEntry(msg as any);
+    expect(result).toContain('<p>HTML content</p>');
+  });
+});

--- a/src/converter/pst.ts
+++ b/src/converter/pst.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { PSTFile, PSTFolder, PSTMessage } from 'pst-extractor';
+
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+/**
+ * DateをmboxのFrom行用日付文字列に変換する
+ * 形式: "Wed Jan 01 00:00:00 2020"
+ */
+export function formatMboxDate(date: Date | null): string {
+  const d = date ?? new Date(0);
+  const day = DAYS[d.getDay()];
+  const mon = MONTHS[d.getMonth()];
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  return `${day} ${mon} ${dd} ${hh}:${mm}:${ss} ${d.getFullYear()}`;
+}
+
+/**
+ * PSTMessageを1件分のmboxエントリ文字列に変換する
+ */
+export function buildMboxEntry(message: PSTMessage): string {
+  const from = message.senderEmailAddress || 'unknown@unknown.com';
+  const dateStr = formatMboxDate(message.clientSubmitTime);
+  const fromLine = `From ${from} ${dateStr}\n`;
+
+  let headers: string;
+  if (message.transportMessageHeaders && message.transportMessageHeaders.trim()) {
+    headers = message.transportMessageHeaders.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    if (!headers.endsWith('\n')) headers += '\n';
+  } else {
+    const date = message.clientSubmitTime
+      ? message.clientSubmitTime.toUTCString()
+      : new Date(0).toUTCString();
+    headers = [
+      `From: ${from}`,
+      `To: ${message.displayTo || ''}`,
+      `Subject: ${message.subject || ''}`,
+      `Date: ${date}`,
+      `Content-Type: text/plain; charset=utf-8`,
+    ].join('\n') + '\n';
+  }
+
+  const rawBody = message.body || message.bodyHTML || '';
+  // mboxエスケープ: 本文中の行頭 "From " を ">From " に変換
+  const body = rawBody.replace(/^From /gm, '>From ');
+
+  return `${fromLine}${headers}\n${body}\n\n`;
+}
+
+/**
+ * PSTフォルダを再帰的にたどり、全メッセージを収集してmbox文字列を構築する
+ */
+function collectMessages(
+  folder: PSTFolder,
+  onMessage: (msg: PSTMessage) => void
+): void {
+  if (folder.contentCount > 0) {
+    let msg = folder.getNextChild();
+    while (msg != null) {
+      if (msg instanceof PSTMessage) {
+        onMessage(msg);
+      }
+      msg = folder.getNextChild();
+    }
+  }
+  for (const subFolder of folder.getSubFolders()) {
+    collectMessages(subFolder, onMessage);
+  }
+}
+
+/**
+ * PSTファイルをmboxファイルに変換して一時ファイルパスを返す
+ */
+export async function convertPstToMbox(
+  pstPath: string,
+  onProgress?: (percent: number, count: number) => void
+): Promise<string> {
+  const outPath = path.join(os.tmpdir(), `mailark-${Date.now()}.mbox`);
+  const writeStream = fs.createWriteStream(outPath, { encoding: 'utf-8' });
+
+  return new Promise((resolve, reject) => {
+    try {
+      const pstFile = new PSTFile(pstPath);
+      const root = pstFile.getRootFolder();
+
+      // 全メッセージ数を先にカウント（進捗計算用）
+      let totalCount = 0;
+      let processedCount = 0;
+
+      // 先にカウントパス
+      collectMessages(root, () => { totalCount++; });
+
+      // 再度開いて変換
+      const pstFile2 = new PSTFile(pstPath);
+      const root2 = pstFile2.getRootFolder();
+
+      const chunks: string[] = [];
+      collectMessages(root2, (msg) => {
+        chunks.push(buildMboxEntry(msg));
+        processedCount++;
+        if (onProgress && totalCount > 0) {
+          const percent = Math.min(Math.floor(processedCount / totalCount * 100), 99);
+          onProgress(percent, processedCount);
+        }
+      });
+
+      writeStream.write(chunks.join(''), (err) => {
+        if (err) { reject(err); return; }
+        writeStream.end(() => {
+          onProgress?.(100, processedCount);
+          pstFile.close();
+          pstFile2.close();
+          resolve(outPath);
+        });
+      });
+    } catch (err) {
+      writeStream.destroy();
+      reject(err);
+    }
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { parseEmail, EmailMeta, Attachment, ByteRange } from './parser';
 import { parseSearchQuery } from './queryParser';
+import { convertPstToMbox } from './converter/pst';
 
 interface SearchParams {
   query?: string;
@@ -58,7 +59,9 @@ ipcMain.handle('open-mbox-file', async () => {
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ['openFile'],
     filters: [
-      { name: 'mbox files', extensions: ['mbox', 'mbx', ''] },
+      { name: 'Mail files', extensions: ['mbox', 'mbx', 'pst', ''] },
+      { name: 'mbox files', extensions: ['mbox', 'mbx'] },
+      { name: 'Outlook PST', extensions: ['pst'] },
       { name: 'All Files', extensions: ['*'] },
     ],
   });
@@ -66,15 +69,24 @@ ipcMain.handle('open-mbox-file', async () => {
   return result.filePaths[0];
 });
 
-// Read and parse mbox file
+// Read and parse mbox file (PSTの場合は先にmboxへ変換する)
 // 全件はrendererに転送しない。件数だけ返してページ取得はsearch-emailsで行う
 ipcMain.handle('read-mbox', async (_event, filePath: string) => {
   try {
     emailSearchCache.clear();
     emailRangeCache.clear();
     emailMetaList = [];
-    currentMboxPath = filePath;
-    emailMetaList = await parseMboxStream(filePath);
+
+    let mboxPath = filePath;
+    if (filePath.toLowerCase().endsWith('.pst')) {
+      mainWindow?.webContents.send('load-progress', { percent: 0, count: 0, phase: 'converting' });
+      mboxPath = await convertPstToMbox(filePath, (percent, count) => {
+        mainWindow?.webContents.send('load-progress', { percent: Math.floor(percent / 2), count, phase: 'converting' });
+      });
+    }
+
+    currentMboxPath = mboxPath;
+    emailMetaList = await parseMboxStream(mboxPath);
     return { total: emailMetaList.length };
   } catch (err) {
     return { error: (err as Error).message };


### PR DESCRIPTION
## Summary
- `pst-extractor`（MITライセンス）を使いPSTファイルをmboxへ変換
- 変換後の一時mboxをそのまま既存Viewerで開く
- 変換中は既存のプログレスバーで進捗を表示

## 変更内容
- `src/converter/pst.ts` — コンバーター実装
  - `convertPstToMbox`: PST全体を再帰的にたどりmbox一時ファイルを生成、進捗コールバック付き
  - `buildMboxEntry`: PSTMessageをmboxエントリ文字列に変換（`transportMessageHeaders`優先、なければ合成）
  - `formatMboxDate`: mbox `From ` 行用日付フォーマット
  - 本文中の `From ` 行をmboxエスケープ（`>From `）
- `src/main.ts`
  - `.pst`拡張子を検出したら`convertPstToMbox`を実行してからmboxとして読み込む
  - ファイルダイアログに「Outlook PST」フィルタを追加
- `src/__tests__/pstConverter.test.ts` — 9テストケース追加（67/67 pass）

## テスト項目
- [ ] .pstファイルをファイルダイアログで選択できる
- [ ] 変換中にプログレスバーが進む
- [ ] 変換後にメール一覧が表示される
- [ ] .mboxファイルは従来通り開ける（既存動作に影響なし）

Closes #3