### PR TITLE
fix: resolve packaged app icon path

### DIFF
--- a/src/__tests__/iconPath.test.ts
+++ b/src/__tests__/iconPath.test.ts
@@ -11,6 +11,6 @@ describe('getAppIconPath', () => {
   test('パッケージ環境ではResources配下のassets画像を返す', () => {
     const result = getAppIconPath('/Applications/mailark.app/Contents/Resources/app.asar/dist', true);
 
-    expect(result).toBe(path.join('/Applications/mailark.app/Contents/Resources', 'assets', 'mailark-square.png'));
+    expect(result).toBe(path.join('/Applications/mailark.app/Contents/Resources/app.asar', 'assets', 'mailark-square.png'));
   });
 });

--- a/src/iconPath.ts
+++ b/src/iconPath.ts
@@ -4,7 +4,7 @@ const ICON_FILE = 'mailark-square.png';
 
 export function getAppIconPath(currentDir: string, isPackaged: boolean): string {
   const assetBaseDir = isPackaged
-    ? path.resolve(currentDir, '..', '..')
+    ? path.resolve(currentDir, '..')
     : path.resolve(currentDir, '..');
 
   return path.join(assetBaseDir, 'assets', ICON_FILE);


### PR DESCRIPTION
## Summary
- パッケージ版 macOS アプリでアイコン画像パスが 1 階層ずれていた問題を修正
- `/Contents/Resources/assets/...` ではなく `/Contents/Resources/app.asar/assets/...` を参照するように変更

## Changes
- `src/iconPath.ts` の packaged path 解決を修正
- `src/__tests__/iconPath.test.ts` の期待値を配布版の実配置に合わせて更新

## Testing
- `npm test -- --runTestsByPath src/__tests__/iconPath.test.ts`
