### PR TITLE
feat: ローカル日本語全文検索の追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "kuromoji": "^0.1.2",
+        "kuromojin": "^3.0.1",
+        "minisearch": "^7.2.0",
         "pst-extractor": "^1.12.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -1921,6 +1924,55 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kvs/env": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@kvs/env/-/env-2.2.2.tgz",
+      "integrity": "sha512-tvy6eb1IHiQWqgSBjOxJp+gQ8wI/1bT5pWKU0VJL9d8SwAflOpN9777wQ3RY3jUtEUpcQOUtxrxcrMs9VYiNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kvs/indexeddb": "^2.2.2",
+        "@kvs/node-localstorage": "^2.2.2",
+        "@kvs/storage": "^2.2.2",
+        "@kvs/types": "^2.2.2"
+      }
+    },
+    "node_modules/@kvs/indexeddb": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@kvs/indexeddb/-/indexeddb-2.2.2.tgz",
+      "integrity": "sha512-h9Fom6YvbRzMHhBLZKdNNJ/bgla0aBbmVBzUBLUoeEwT3C16Yx5eGA+spUQ69ZoRbsArZufX84qX/wRbyvjtrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kvs/storage": "^2.2.2",
+        "@kvs/types": "^2.2.2"
+      }
+    },
+    "node_modules/@kvs/node-localstorage": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@kvs/node-localstorage/-/node-localstorage-2.2.2.tgz",
+      "integrity": "sha512-e6r2CBWAQznaLEAmYSNNPGXUkSRP+yffSZNJYfgR4II8vjDFtGj1gByo2yk7pQsRiiId6IZ5dwDl1Tib3bNaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kvs/storage": "^2.2.2",
+        "@kvs/types": "^2.2.2",
+        "app-root-path": "^3.1.0",
+        "node-localstorage": "^2.1.6"
+      }
+    },
+    "node_modules/@kvs/storage": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@kvs/storage/-/storage-2.2.2.tgz",
+      "integrity": "sha512-jThnhLTcT0w1SHzhr/PFTzzkKl+V3J6X07NyARceT02mIu5+tBWwtUhS68UNOaD7CTQ07rMFgb5UHoolies94g==",
+      "license": "MIT",
+      "dependencies": {
+        "@kvs/types": "^2.2.2"
+      }
+    },
+    "node_modules/@kvs/types": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@kvs/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-5lmBuah+wOdypBf0O9t6BoHrnq5hX5MlhEPTDPBNKN38ayQwVc5gYgJOBR3Dg4EF7OwL+1c7JNtWXQEJXXVXlg==",
+      "license": "MIT"
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -2859,6 +2911,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/app-root-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/archiver": {
@@ -4091,6 +4152,12 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5042,7 +5109,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -5289,7 +5355,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -6339,6 +6404,37 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kuromoji": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/kuromoji/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/kuromojin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.1.tgz",
+      "integrity": "sha512-E4rLmbTid8ZGH8Fw421UXvfgCe0IXGFKhUw/IosBVW6ootxVGKGbtb0UPQAvPswgsXX/8UuPiE+amz1NN11Uzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kvs/env": "^2.1.3",
+        "kuromoji": "0.1.2",
+        "lru_map": "^0.4.1"
+      }
+    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -6430,7 +6526,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -6495,6 +6590,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6675,6 +6776,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
+    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -6766,6 +6873,29 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-localstorage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
+      "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
+      "license": "MIT",
+      "dependencies": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/node-localstorage/node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -7528,6 +7658,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/smart-buffer": {
@@ -8416,6 +8555,15 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     }
   },
   "dependencies": {
+    "kuromoji": "^0.1.2",
+    "kuromojin": "^3.0.1",
+    "minisearch": "^7.2.0",
     "pst-extractor": "^1.12.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/src/__tests__/lazySearchIndex.test.ts
+++ b/src/__tests__/lazySearchIndex.test.ts
@@ -1,0 +1,92 @@
+import { createLazySearchIndex } from '../lazySearchIndex';
+import { SearchDocument, SearchResult, SearchRunner } from '../searchEngine';
+
+class FakeSearchIndex implements SearchRunner {
+  constructor(private readonly results: SearchResult[]) {}
+
+  async search(): Promise<SearchResult[]> {
+    return this.results;
+  }
+}
+
+describe('createLazySearchIndex', () => {
+  test('検索が走るまで index を構築しない', async () => {
+    const docs: SearchDocument[] = [];
+    let buildCount = 0;
+    const lazyIndex = createLazySearchIndex({
+      tokenizer: async () => [],
+      buildIndex: async (buildDocs) => {
+        buildCount += 1;
+        docs.push(...buildDocs);
+        return new FakeSearchIndex([]);
+      },
+    });
+
+    lazyIndex.add({
+      id: 'mail-1',
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: '件名',
+      body: '本文',
+    });
+
+    expect(buildCount).toBe(0);
+    expect(lazyIndex.size()).toBe(1);
+
+    await lazyIndex.search('本文');
+
+    expect(buildCount).toBe(1);
+    expect(docs).toHaveLength(1);
+  });
+
+  test('2回目以降の検索では index を再構築しない', async () => {
+    let buildCount = 0;
+    const lazyIndex = createLazySearchIndex({
+      tokenizer: async () => [],
+      buildIndex: async () => {
+        buildCount += 1;
+        return new FakeSearchIndex([{ id: 'mail-1', score: 1 }]);
+      },
+    });
+
+    lazyIndex.add({
+      id: 'mail-1',
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: '件名',
+      body: '本文',
+    });
+
+    await lazyIndex.search('本文');
+    await lazyIndex.search('件名');
+
+    expect(buildCount).toBe(1);
+  });
+
+  test('並列検索でも index 構築は1回だけにする', async () => {
+    let buildCount = 0;
+    const lazyIndex = createLazySearchIndex({
+      tokenizer: async () => [],
+      buildIndex: async () => {
+        buildCount += 1;
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return new FakeSearchIndex([{ id: 'mail-1', score: 1 }]);
+      },
+    });
+
+    lazyIndex.add({
+      id: 'mail-1',
+      from: 'a@example.com',
+      to: 'b@example.com',
+      subject: '件名',
+      body: '本文',
+    });
+
+    await Promise.all([
+      lazyIndex.search('本文'),
+      lazyIndex.search('件名'),
+    ]);
+
+    expect(buildCount).toBe(1);
+  });
+});

--- a/src/__tests__/searchEngine.test.ts
+++ b/src/__tests__/searchEngine.test.ts
@@ -1,0 +1,58 @@
+import { buildSearchIndex, SearchDocument } from '../searchEngine';
+
+async function tokenize(text: string): Promise<string[]> {
+  const normalized = text
+    .replace(/[。、,]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return [];
+
+  const dictionary: Record<string, string[]> = {
+    '買い出し担当': ['買い出し', '担当'],
+    'じゃがいもの担当': ['じゃがいも', '担当'],
+    '買い出し': ['買い出し'],
+    '担当': ['担当'],
+    'カレーの具材候補の整理': ['カレー', '具材', '候補', '整理'],
+    'じゃがいもを買う担当は中村さんでお願いします': ['じゃがいも', '買う', '担当', '中村'],
+    '買い出し担当と予算の確認': ['買い出し', '担当', '予算', '確認'],
+    '予算メモ': ['予算', 'メモ'],
+  };
+
+  return dictionary[normalized] || normalized.split(' ');
+}
+
+describe('buildSearchIndex', () => {
+  const docs: SearchDocument[] = [
+    {
+      id: 'body-hit',
+      from: 'emi@example.com',
+      to: 'team@example.com',
+      subject: '予算メモ',
+      body: 'じゃがいもを買う担当は中村さんでお願いします',
+    },
+    {
+      id: 'subject-hit',
+      from: 'aki@example.com',
+      to: 'team@example.com',
+      subject: '買い出し担当と予算の確認',
+      body: '集合時間を確認したいです',
+    },
+  ];
+
+  test('日本語自然文を token 化して本文から検索できる', async () => {
+    const index = await buildSearchIndex(docs, tokenize);
+
+    const results = await index.search('じゃがいもの担当');
+    const resultIds = results.map(result => result.id);
+
+    expect(resultIds).toContain('body-hit');
+  });
+
+  test('件名ヒットを本文ヒットより高く評価する', async () => {
+    const index = await buildSearchIndex(docs, tokenize);
+
+    const results = await index.search('買い出し担当');
+
+    expect(results[0]?.id).toBe('subject-hit');
+  });
+});

--- a/src/__tests__/searchEngine.test.ts
+++ b/src/__tests__/searchEngine.test.ts
@@ -55,4 +55,52 @@ describe('buildSearchIndex', () => {
 
     expect(results[0]?.id).toBe('subject-hit');
   });
+
+  test('from/to は kuromoji を使わずに検索 index を作る', async () => {
+    const tokenizeCalls: string[] = [];
+    const index = await buildSearchIndex([
+      {
+        id: 'mail-1',
+        from: 'emi@example.com',
+        to: 'team@example.com',
+        subject: '件名',
+        body: '本文',
+      },
+    ], async text => {
+      tokenizeCalls.push(text);
+      return text.split(/\s+/).filter(Boolean);
+    });
+
+    const results = await index.search('emi example com');
+
+    expect(results[0]?.id).toBe('mail-1');
+    expect(tokenizeCalls).not.toContain('emi@example.com');
+    expect(tokenizeCalls).not.toContain('team@example.com');
+  });
+
+  test('同じ件名と本文では token 化結果を使い回す', async () => {
+    const tokenizeCalls: string[] = [];
+
+    await buildSearchIndex([
+      {
+        id: 'mail-1',
+        from: 'a@example.com',
+        to: 'team@example.com',
+        subject: '進捗共有',
+        body: '今週の進捗共有です',
+      },
+      {
+        id: 'mail-2',
+        from: 'b@example.com',
+        to: 'team@example.com',
+        subject: '進捗共有',
+        body: '今週の進捗共有です',
+      },
+    ], async text => {
+      tokenizeCalls.push(text);
+      return text.split(/\s+/).filter(Boolean);
+    });
+
+    expect(tokenizeCalls).toEqual(['進捗共有', '今週の進捗共有です']);
+  });
 });

--- a/src/__tests__/searchIndexManager.test.ts
+++ b/src/__tests__/searchIndexManager.test.ts
@@ -1,0 +1,113 @@
+import { SearchDocument, SearchResult, SearchRunner, SearchTokenizer } from '../searchEngine';
+import { SearchIndexManager } from '../searchIndexManager';
+import { SearchStatus } from '../searchStatus';
+
+class FakeSearchRunner implements SearchRunner {
+  constructor(private readonly results: SearchResult[]) {}
+
+  async search(): Promise<SearchResult[]> {
+    return this.results;
+  }
+}
+
+function createDoc(id: string): SearchDocument {
+  return {
+    id,
+    from: `${id}@example.com`,
+    to: 'team@example.com',
+    subject: `subject-${id}`,
+    body: `body-${id}`,
+  };
+}
+
+describe('SearchIndexManager', () => {
+  test('replaceAll 後の search は最新の index 構築完了を待つ', async () => {
+    let resolveBuild: ((runner: SearchRunner) => void) | null = null;
+    const manager = new SearchIndexManager({
+      tokenizer: async () => [],
+      buildIndex: async () => new Promise<SearchRunner>(resolve => {
+        resolveBuild = resolve;
+      }),
+    });
+
+    manager.replaceAll([createDoc('mail-1')]);
+    const searchPromise = manager.search('mail-1');
+
+    expect(resolveBuild).not.toBeNull();
+    resolveBuild!(new FakeSearchRunner([{ id: 'mail-1', score: 1 }]));
+
+    await expect(searchPromise).resolves.toEqual([{ id: 'mail-1', score: 1 }]);
+  });
+
+  test('reset が走ったら古い build 結果を採用しない', async () => {
+    let resolveBuild: ((runner: SearchRunner) => void) | null = null;
+    const manager = new SearchIndexManager({
+      tokenizer: async () => [],
+      buildIndex: async () => new Promise<SearchRunner>(resolve => {
+        resolveBuild = resolve;
+      }),
+    });
+
+    manager.replaceAll([createDoc('mail-1')]);
+    const searchPromise = manager.search('mail-1');
+    manager.reset();
+    expect(resolveBuild).not.toBeNull();
+    resolveBuild!(new FakeSearchRunner([{ id: 'mail-1', score: 1 }]));
+
+    await expect(searchPromise).resolves.toEqual([]);
+  });
+
+  test('より新しい replaceAll が来たら古い build 結果を採用しない', async () => {
+    const resolves: Array<(runner: SearchRunner) => void> = [];
+    const docsBuilt: string[][] = [];
+    const tokenizer: SearchTokenizer = async () => [];
+    const manager = new SearchIndexManager({
+      tokenizer,
+      buildIndex: async (docs: SearchDocument[]) => {
+        docsBuilt.push(docs.map(doc => doc.id));
+        return new Promise<SearchRunner>(resolve => {
+          resolves.push(resolve);
+        });
+      },
+    });
+
+    manager.replaceAll([createDoc('mail-1')]);
+    manager.replaceAll([createDoc('mail-2')]);
+
+    resolves[0](new FakeSearchRunner([{ id: 'mail-1', score: 1 }]));
+    resolves[1](new FakeSearchRunner([{ id: 'mail-2', score: 2 }]));
+
+    await expect(manager.search('mail-2')).resolves.toEqual([{ id: 'mail-2', score: 2 }]);
+    expect(docsBuilt).toEqual([['mail-1'], ['mail-2']]);
+  });
+
+  test('index 構築の状態変化を通知する', async () => {
+    const statuses: SearchStatus[] = [];
+    const manager = new SearchIndexManager({
+      tokenizer: async () => [],
+      onStatusChange: status => {
+        statuses.push(status);
+      },
+    });
+
+    manager.replaceAll([createDoc('mail-1'), createDoc('mail-2')]);
+    await manager.search('mail-1');
+
+    expect(statuses).toContainEqual({ phase: 'indexing', indexed: 0, total: 2 });
+    expect(statuses).toContainEqual({ phase: 'ready', total: 2 });
+  });
+
+  test('reset 時に idle を通知する', () => {
+    const statuses: SearchStatus[] = [];
+    const manager = new SearchIndexManager({
+      tokenizer: async () => [],
+      onStatusChange: status => {
+        statuses.push(status);
+      },
+    });
+
+    manager.reset();
+
+    expect(statuses).toContainEqual({ phase: 'idle' });
+  });
+});

--- a/src/__tests__/searchInputBehavior.test.ts
+++ b/src/__tests__/searchInputBehavior.test.ts
@@ -1,0 +1,12 @@
+import { shouldSubmitSearch } from '../searchInputBehavior';
+
+describe('shouldSubmitSearch', () => {
+  test('Enter キーでのみ検索を送信する', () => {
+    expect(shouldSubmitSearch('Enter', false)).toBe(true);
+    expect(shouldSubmitSearch('a', false)).toBe(false);
+  });
+
+  test('IME 変換中の Enter では検索を送信しない', () => {
+    expect(shouldSubmitSearch('Enter', true)).toBe(false);
+  });
+});

--- a/src/__tests__/searchStatus.test.ts
+++ b/src/__tests__/searchStatus.test.ts
@@ -1,0 +1,11 @@
+import { describeSearchStatus } from '../searchStatus';
+
+describe('describeSearchStatus', () => {
+  test('index 構築中の進捗を表示する', () => {
+    expect(describeSearchStatus({ phase: 'indexing', indexed: 25, total: 100 })).toBe('検索 index 構築中 25 / 100');
+  });
+
+  test('検索結果件数を表示する', () => {
+    expect(describeSearchStatus({ phase: 'searched', query: '会議', hitCount: 3, total: 120 })).toBe('自然言語検索 3 / 120 件');
+  });
+});

--- a/src/__tests__/searchTokenizer.test.ts
+++ b/src/__tests__/searchTokenizer.test.ts
@@ -1,0 +1,59 @@
+import { tokenizeJapaneseText, normalizeSearchText } from '../searchTokenizer';
+
+describe('normalizeSearchText', () => {
+  test('全角英数字をASCIIに正規化する', () => {
+    expect(normalizeSearchText('Ａｂｃ１２３')).toBe('abc123');
+  });
+
+  test('URLをスペースに置き換える', () => {
+    const result = normalizeSearchText('詳細は https://example.com を参照');
+    expect(result).not.toContain('https://');
+    expect(result).toContain('詳細');
+    expect(result).toContain('参照');
+  });
+
+  test('記号をスペースに変換する', () => {
+    expect(normalizeSearchText('hello-world')).toBe('hello world');
+  });
+
+  test('空文字列は空文字列を返す', () => {
+    expect(normalizeSearchText('')).toBe('');
+  });
+
+  test('連続スペースを1つに正規化する', () => {
+    expect(normalizeSearchText('a   b')).toBe('a b');
+  });
+});
+
+describe('tokenizeJapaneseText', () => {
+  // kuromoji の辞書ロードを伴うため timeout を長めに設定
+  const TIMEOUT = 15000;
+
+  test('名詞が抽出される', async () => {
+    const tokens = await tokenizeJapaneseText('東京の桜');
+    expect(tokens).toContain('東京');
+    expect(tokens).toContain('桜');
+  }, TIMEOUT);
+
+  test('助詞が除去される', async () => {
+    const tokens = await tokenizeJapaneseText('東京の桜');
+    expect(tokens).not.toContain('の');
+  }, TIMEOUT);
+
+  test('動詞の surface または basic_form が含まれる', async () => {
+    const tokens = await tokenizeJapaneseText('メールを送った');
+    // surface_form「送っ」または basic_form「送る」のいずれかが含まれる
+    const hasVerb = tokens.some(t => t.startsWith('送'));
+    expect(hasVerb).toBe(true);
+  }, TIMEOUT);
+
+  test('空文字列は空配列を返す', async () => {
+    const tokens = await tokenizeJapaneseText('');
+    expect(tokens).toEqual([]);
+  }, TIMEOUT);
+
+  test('記号のみの文字列は空配列を返す', async () => {
+    const tokens = await tokenizeJapaneseText('---');
+    expect(tokens).toEqual([]);
+  }, TIMEOUT);
+});

--- a/src/__tests__/searchableBody.test.ts
+++ b/src/__tests__/searchableBody.test.ts
@@ -1,0 +1,21 @@
+import { extractSearchableBody } from '../searchableBody';
+
+describe('extractSearchableBody', () => {
+  test('HTML をテキスト化して検索対象本文を作る', () => {
+    const body = extractSearchableBody('', '<html><body><h1>会議</h1><p>来週の予定</p></body></html>');
+
+    expect(body).toBe('会議 来週の予定');
+  });
+
+  test('長すぎる本文は上限で切り詰める', () => {
+    const longText = 'あ'.repeat(5000);
+
+    expect(extractSearchableBody(longText, '')).toHaveLength(4000);
+  });
+
+  test('base64 っぽい長い断片は除外する', () => {
+    const binaryish = `会議 ${'A'.repeat(120)} 議事録`;
+
+    expect(extractSearchableBody(binaryish, '')).toBe('会議 議事録');
+  });
+});

--- a/src/__tests__/searchableBody.test.ts
+++ b/src/__tests__/searchableBody.test.ts
@@ -10,7 +10,7 @@ describe('extractSearchableBody', () => {
   test('長すぎる本文は上限で切り詰める', () => {
     const longText = 'あ'.repeat(5000);
 
-    expect(extractSearchableBody(longText, '')).toHaveLength(4000);
+    expect(extractSearchableBody(longText, '')).toHaveLength(2000);
   });
 
   test('base64 っぽい長い断片は除外する', () => {

--- a/src/backgroundSearchIndex.ts
+++ b/src/backgroundSearchIndex.ts
@@ -1,0 +1,81 @@
+import * as path from 'path';
+import { Worker } from 'worker_threads';
+import { SearchDocument, SearchResult } from './searchEngine';
+import { SearchWorkerRequest, SearchWorkerResponse } from './searchWorkerProtocol';
+import { SearchStatus } from './searchStatus';
+
+export interface BackgroundSearchIndex {
+  replaceAll(docs: SearchDocument[]): void;
+  reset(): void;
+  search(query: string): Promise<SearchResult[]>;
+}
+
+interface BackgroundSearchIndexOptions {
+  onStatusChange?: (status: SearchStatus) => void;
+}
+
+interface PendingRequest {
+  resolve: (value: null | SearchResult[]) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export function createBackgroundSearchIndex(
+  options: BackgroundSearchIndexOptions = {},
+): BackgroundSearchIndex {
+  const worker = new Worker(path.join(__dirname, 'searchWorker.js'));
+  const pendingRequests = new Map<number, PendingRequest>();
+  let nextId = 1;
+
+  worker.on('message', (message: SearchWorkerResponse) => {
+    if (message.kind === 'status') {
+      options.onStatusChange?.(message.status);
+      return;
+    }
+
+    const pending = pendingRequests.get(message.id);
+    if (!pending) return;
+    pendingRequests.delete(message.id);
+
+    if (message.ok) {
+      pending.resolve(message.result);
+      return;
+    }
+
+    pending.reject(new Error(message.error));
+  });
+
+  worker.on('error', err => {
+    for (const pending of pendingRequests.values()) {
+      pending.reject(err);
+    }
+    pendingRequests.clear();
+  });
+
+  return {
+    replaceAll(docs: SearchDocument[]) {
+      void send('replaceAll', { docs }).catch(err => {
+        console.error('[backgroundSearchIndex] replaceAll failed:', err);
+      });
+    },
+    reset() {
+      void send('reset', {}).catch(err => {
+        console.error('[backgroundSearchIndex] reset failed:', err);
+      });
+    },
+    async search(query: string) {
+      const result = await send('search', { query });
+      return result || [];
+    },
+  };
+
+  function send(
+    type: SearchWorkerRequest['type'],
+    payload: Pick<SearchWorkerRequest, 'docs' | 'query'>,
+  ): Promise<null | SearchResult[]> {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      pendingRequests.set(id, { resolve, reject });
+      worker.postMessage({ id, type, ...payload } satisfies SearchWorkerRequest);
+    });
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -144,6 +144,15 @@
     font-family: 'DM Mono', monospace;
     white-space: nowrap;
   }
+  #search-status {
+    font-size: 11px;
+    color: var(--accent2);
+    font-family: 'DM Mono', monospace;
+    white-space: nowrap;
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   #filter-unknown-label {
     display: flex;
     align-items: center;

--- a/src/lazySearchIndex.ts
+++ b/src/lazySearchIndex.ts
@@ -1,0 +1,53 @@
+import { buildSearchIndex, SearchDocument, SearchResult, SearchRunner, SearchTokenizer } from './searchEngine';
+
+interface LazySearchIndexOptions {
+  tokenizer: SearchTokenizer;
+  buildIndex?: (docs: SearchDocument[], tokenizer: SearchTokenizer) => Promise<SearchRunner>;
+}
+
+export interface LazySearchIndex {
+  add(doc: SearchDocument): void;
+  reset(): void;
+  search(query: string): Promise<SearchResult[]>;
+  size(): number;
+}
+
+export function createLazySearchIndex({
+  tokenizer,
+  buildIndex = buildSearchIndex,
+}: LazySearchIndexOptions): LazySearchIndex {
+  const docs: SearchDocument[] = [];
+  let index: SearchRunner | null = null;
+  let buildPromise: Promise<SearchRunner> | null = null;
+
+  return {
+    add(doc: SearchDocument) {
+      docs.push(doc);
+    },
+    reset() {
+      docs.length = 0;
+      index = null;
+      buildPromise = null;
+    },
+    size() {
+      return docs.length;
+    },
+    async search(query: string) {
+      const searchIndex = await ensureIndex();
+      return searchIndex.search(query);
+    },
+  };
+
+  async function ensureIndex(): Promise<SearchRunner> {
+    if (index) return index;
+    if (!buildPromise) {
+      buildPromise = buildIndex([...docs], tokenizer).then(createdIndex => {
+        index = createdIndex;
+        return createdIndex;
+      }).finally(() => {
+        buildPromise = null;
+      });
+    }
+    return buildPromise;
+  }
+}

--- a/src/lazySearchIndex.ts
+++ b/src/lazySearchIndex.ts
@@ -19,12 +19,15 @@ export function createLazySearchIndex({
   const docs: SearchDocument[] = [];
   let index: SearchRunner | null = null;
   let buildPromise: Promise<SearchRunner> | null = null;
+  // reset() が呼ばれるたびにインクリメントし、古い buildPromise の結果を破棄する
+  let generation = 0;
 
   return {
     add(doc: SearchDocument) {
       docs.push(doc);
     },
     reset() {
+      generation++;
       docs.length = 0;
       index = null;
       buildPromise = null;
@@ -40,12 +43,18 @@ export function createLazySearchIndex({
 
   async function ensureIndex(): Promise<SearchRunner> {
     if (index) return index;
+    const currentGeneration = generation;
     if (!buildPromise) {
       buildPromise = buildIndex([...docs], tokenizer).then(createdIndex => {
-        index = createdIndex;
+        // reset() が呼ばれた場合（世代が変わった場合）は古いインデックスを捨てる
+        if (generation === currentGeneration) {
+          index = createdIndex;
+        }
         return createdIndex;
       }).finally(() => {
-        buildPromise = null;
+        if (generation === currentGeneration) {
+          buildPromise = null;
+        }
       });
     }
     return buildPromise;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,8 @@ import { parseSearchQuery } from './queryParser';
 import { convertPstToMbox, readPstAttachments } from './converter/pst';
 import { getAppIconPath } from './iconPath';
 import { applyAppMetadata } from './appMetadata';
-import { buildSearchIndex, SearchDocument, SearchIndex } from './searchEngine';
 import { tokenizeJapaneseText } from './searchTokenizer';
+import { createLazySearchIndex } from './lazySearchIndex';
 
 interface SearchParams {
   query?: string;
@@ -20,7 +20,6 @@ interface SearchParams {
 
 let mainWindow: BrowserWindow | null = null;
 
-const emailSearchDocuments: SearchDocument[] = [];
 // メールの byte 範囲。detail 取得時にファイルを再読み込みするために使う
 const emailRangeCache = new Map<string, ByteRange>();
 // PST由来メールのdescriptor ID。添付ファイルをオンデマンドで取得するために使う
@@ -31,7 +30,9 @@ let emailMetaList: EmailMeta[] = [];
 const emailMboxPathCache = new Map<string, string>();
 // メールIDごとのPSTファイルパス（PST由来添付のオンデマンド取得用）
 const emailPstPathCache = new Map<string, string>();
-let emailSearchIndex: SearchIndex | null = null;
+const emailSearchIndex = createLazySearchIndex({
+  tokenizer: tokenizeJapaneseText,
+});
 
 function createWindow(): void {
   const icon = getAppIconPath(__dirname, app.isPackaged);
@@ -92,13 +93,12 @@ ipcMain.handle('open-mbox-file', async () => {
 // 複数ファイルをマージして読み込む。全件はrendererに転送しない。件数だけ返す
 ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
   try {
-    emailSearchDocuments.length = 0;
     emailRangeCache.clear();
     pstDescriptorCache.clear();
     emailMboxPathCache.clear();
     emailPstPathCache.clear();
     emailMetaList = [];
-    emailSearchIndex = null;
+    emailSearchIndex.reset();
 
     for (let i = 0; i < filePaths.length; i++) {
       const filePath = filePaths[i];
@@ -122,9 +122,6 @@ ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
       const newEmails = await parseMboxStream(mboxPath, pstPath);
       emailMetaList = emailMetaList.concat(newEmails);
     }
-
-    emailSearchIndex = await buildSearchIndex(emailSearchDocuments, tokenizeJapaneseText);
-
     return { total: emailMetaList.length };
   } catch (err) {
     return { error: (err as Error).message };
@@ -191,7 +188,7 @@ ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100,
     });
 
     if (parsed.text) {
-      const searchResults = emailSearchIndex ? await emailSearchIndex.search(parsed.text) : [];
+      const searchResults = await emailSearchIndex.search(parsed.text);
       scoredSearchResults = new Map(searchResults.map(result => [result.id, result.score]));
       results = results.filter(em => scoredSearchResults.has(em.id));
     }
@@ -250,7 +247,7 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
         const email = parseEmail(raw);
         if (!email) return;
 
-        emailSearchDocuments.push({
+        emailSearchIndex.add({
           id: email.id,
           from: email.from,
           to: email.to,

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,7 @@ ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100,
 
   if (query) {
     const parsed = parseSearchQuery(query);
+    // ① 構造フィルタ（from/to/since/until）で候補を絞る
     results = results.filter(em => {
       if (parsed.from && !em.from.toLowerCase().includes(parsed.from.toLowerCase())) return false;
       if (parsed.to && !em.to.toLowerCase().includes(parsed.to.toLowerCase())) return false;
@@ -187,6 +188,7 @@ ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100,
       return true;
     });
 
+    // ② 全文検索インデックスでさらに絞り込み、スコアを取得
     if (parsed.text) {
       const searchResults = await emailSearchIndex.search(parsed.text);
       scoredSearchResults = new Map(searchResults.map(result => [result.id, result.score]));
@@ -330,6 +332,9 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
   });
 }
 
+// NOTE: style/script タグ内のノイズを先に除去してからタグを削除する。
+// ただし正規表現ベースのため、ネストしたコメントや非標準タグには対応できない。
+// 将来的に軽量HTMLパーサー（node-html-parser 等）への移行を検討すること。
 function extractSearchableBody(body: string, htmlBody: string): string {
   if (body.trim()) return body;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,10 @@ import { parseSearchQuery } from './queryParser';
 import { convertPstToMbox, readPstAttachments } from './converter/pst';
 import { getAppIconPath } from './iconPath';
 import { applyAppMetadata } from './appMetadata';
-import { tokenizeJapaneseText } from './searchTokenizer';
-import { createLazySearchIndex } from './lazySearchIndex';
+import { createBackgroundSearchIndex } from './backgroundSearchIndex';
+import { SearchDocument } from './searchEngine';
+import { SearchStatus } from './searchStatus';
+import { extractSearchableBody } from './searchableBody';
 
 interface SearchParams {
   query?: string;
@@ -30,8 +32,13 @@ let emailMetaList: EmailMeta[] = [];
 const emailMboxPathCache = new Map<string, string>();
 // メールIDごとのPSTファイルパス（PST由来添付のオンデマンド取得用）
 const emailPstPathCache = new Map<string, string>();
-const emailSearchIndex = createLazySearchIndex({
-  tokenizer: tokenizeJapaneseText,
+const emailSearchDocuments: SearchDocument[] = [];
+let latestSearchStatus: SearchStatus = { phase: 'idle' };
+const emailSearchIndex = createBackgroundSearchIndex({
+  onStatusChange: status => {
+    latestSearchStatus = status;
+    mainWindow?.webContents.send('search-status', status);
+  },
 });
 
 function createWindow(): void {
@@ -89,6 +96,8 @@ ipcMain.handle('open-mbox-file', async () => {
   return result.filePaths;
 });
 
+ipcMain.handle('get-search-status', async () => latestSearchStatus);
+
 // Read and parse mbox files (PSTの場合は先にmboxへ変換する)
 // 複数ファイルをマージして読み込む。全件はrendererに転送しない。件数だけ返す
 ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
@@ -98,7 +107,9 @@ ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
     emailMboxPathCache.clear();
     emailPstPathCache.clear();
     emailMetaList = [];
+    emailSearchDocuments.length = 0;
     emailSearchIndex.reset();
+    latestSearchStatus = { phase: 'idle' };
 
     for (let i = 0; i < filePaths.length; i++) {
       const filePath = filePaths[i];
@@ -122,6 +133,7 @@ ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
       const newEmails = await parseMboxStream(mboxPath, pstPath);
       emailMetaList = emailMetaList.concat(newEmails);
     }
+    emailSearchIndex.replaceAll(emailSearchDocuments);
     return { total: emailMetaList.length };
   } catch (err) {
     return { error: (err as Error).message };
@@ -249,7 +261,7 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
         const email = parseEmail(raw);
         if (!email) return;
 
-        emailSearchIndex.add({
+        emailSearchDocuments.push({
           id: email.id,
           from: email.from,
           to: email.to,
@@ -330,18 +342,4 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
 
     fileStream.on('error', reject);
   });
-}
-
-// NOTE: style/script タグ内のノイズを先に除去してからタグを削除する。
-// ただし正規表現ベースのため、ネストしたコメントや非標準タグには対応できない。
-// 将来的に軽量HTMLパーサー（node-html-parser 等）への移行を検討すること。
-function extractSearchableBody(body: string, htmlBody: string): string {
-  if (body.trim()) return body;
-
-  return htmlBody
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ import { parseSearchQuery } from './queryParser';
 import { convertPstToMbox, readPstAttachments } from './converter/pst';
 import { getAppIconPath } from './iconPath';
 import { applyAppMetadata } from './appMetadata';
+import { buildSearchIndex, SearchDocument, SearchIndex } from './searchEngine';
+import { tokenizeJapaneseText } from './searchTokenizer';
 
 interface SearchParams {
   query?: string;
@@ -18,8 +20,7 @@ interface SearchParams {
 
 let mainWindow: BrowserWindow | null = null;
 
-// 検索用テキスト（最大500文字・小文字）のみを保持。body/htmlBody/添付は持たない
-const emailSearchCache = new Map<string, string>();
+const emailSearchDocuments: SearchDocument[] = [];
 // メールの byte 範囲。detail 取得時にファイルを再読み込みするために使う
 const emailRangeCache = new Map<string, ByteRange>();
 // PST由来メールのdescriptor ID。添付ファイルをオンデマンドで取得するために使う
@@ -30,6 +31,7 @@ let emailMetaList: EmailMeta[] = [];
 const emailMboxPathCache = new Map<string, string>();
 // メールIDごとのPSTファイルパス（PST由来添付のオンデマンド取得用）
 const emailPstPathCache = new Map<string, string>();
+let emailSearchIndex: SearchIndex | null = null;
 
 function createWindow(): void {
   const icon = getAppIconPath(__dirname, app.isPackaged);
@@ -90,12 +92,13 @@ ipcMain.handle('open-mbox-file', async () => {
 // 複数ファイルをマージして読み込む。全件はrendererに転送しない。件数だけ返す
 ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
   try {
-    emailSearchCache.clear();
+    emailSearchDocuments.length = 0;
     emailRangeCache.clear();
     pstDescriptorCache.clear();
     emailMboxPathCache.clear();
     emailPstPathCache.clear();
     emailMetaList = [];
+    emailSearchIndex = null;
 
     for (let i = 0; i < filePaths.length; i++) {
       const filePath = filePaths[i];
@@ -119,6 +122,8 @@ ipcMain.handle('read-mbox', async (_event, filePaths: string[]) => {
       const newEmails = await parseMboxStream(mboxPath, pstPath);
       emailMetaList = emailMetaList.concat(newEmails);
     }
+
+    emailSearchIndex = await buildSearchIndex(emailSearchDocuments, tokenizeJapaneseText);
 
     return { total: emailMetaList.length };
   } catch (err) {
@@ -169,6 +174,7 @@ ipcMain.handle('get-email-detail', async (_event, id: string) => {
 // ページネーション付き検索
 ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100, sortOrder = 'desc', excludeUnknown = false }: SearchParams) => {
   let results = emailMetaList;
+  let scoredSearchResults = new Map<string, number>();
 
   if (excludeUnknown) {
     results = results.filter(em => !em.from.toLowerCase().includes('unknown@unknown.com'));
@@ -181,20 +187,18 @@ ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100,
       if (parsed.to && !em.to.toLowerCase().includes(parsed.to.toLowerCase())) return false;
       if (parsed.since !== undefined && em.dateObj < parsed.since) return false;
       if (parsed.until !== undefined && em.dateObj > parsed.until) return false;
-      if (parsed.text) {
-        const q = parsed.text.toLowerCase();
-        if (em.from.toLowerCase().includes(q)) return true;
-        if (em.to.toLowerCase().includes(q)) return true;
-        if (em.subject.toLowerCase().includes(q)) return true;
-        const searchText = emailSearchCache.get(em.id) || '';
-        return searchText.includes(q);
-      }
       return true;
     });
+
+    if (parsed.text) {
+      const searchResults = emailSearchIndex ? await emailSearchIndex.search(parsed.text) : [];
+      scoredSearchResults = new Map(searchResults.map(result => [result.id, result.score]));
+      results = results.filter(em => scoredSearchResults.has(em.id));
+    }
   }
 
   const sorted = results.slice().sort((a, b) =>
-    sortOrder === 'asc' ? a.dateObj - b.dateObj : b.dateObj - a.dateObj
+    compareSearchResults(a, b, sortOrder, scoredSearchResults)
   );
 
   return {
@@ -202,6 +206,17 @@ ipcMain.handle('search-emails', async (_event, { query, offset = 0, limit = 100,
     emails: sorted.slice(offset, offset + limit),
   };
 });
+
+function compareSearchResults(
+  a: EmailMeta,
+  b: EmailMeta,
+  sortOrder: 'asc' | 'desc',
+  scoredSearchResults: Map<string, number>,
+): number {
+  const scoreDiff = (scoredSearchResults.get(b.id) || 0) - (scoredSearchResults.get(a.id) || 0);
+  if (scoreDiff !== 0) return scoreDiff;
+  return sortOrder === 'asc' ? a.dateObj - b.dateObj : b.dateObj - a.dateObj;
+}
 
 // Save attachment to temp and open
 ipcMain.handle('save-attachment', async (_event, { filename, data }: { filename: string; data: string }) => {
@@ -215,7 +230,7 @@ ipcMain.handle('save-attachment', async (_event, { filename, data }: { filename:
 // ─── mbox parser ────────────────────────────────────────────────────────────
 
 // Buffer ベースのストリームパーサー。byte offset を追跡して再読み込みに備える。
-// body/htmlBody/添付は flush 後に捨て、検索用テキスト（最大500文字）だけ保持。
+// body/htmlBody/添付は flush 後に捨て、検索 index 用の最小データだけ保持する。
 function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
   return new Promise((resolve, reject) => {
     const fileSize = fs.statSync(filePath).size;
@@ -235,12 +250,13 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
         const email = parseEmail(raw);
         if (!email) return;
 
-        // 検索用テキスト（最大500文字・小文字）だけ保持
-        let searchText = email.body;
-        if (!searchText && email.htmlBody) {
-          searchText = email.htmlBody.replace(/<[^>]*>/g, ' ');
-        }
-        emailSearchCache.set(email.id, searchText.slice(0, 500).toLowerCase());
+        emailSearchDocuments.push({
+          id: email.id,
+          from: email.from,
+          to: email.to,
+          subject: email.subject,
+          body: extractSearchableBody(email.body, email.htmlBody),
+        });
         emailRangeCache.set(email.id, { byteStart, byteEnd });
         emailMboxPathCache.set(email.id, filePath);
         if (pstPath) emailPstPathCache.set(email.id, pstPath);
@@ -315,4 +331,15 @@ function parseMboxStream(filePath: string, pstPath = ''): Promise<EmailMeta[]> {
 
     fileStream.on('error', reject);
   });
+}
+
+function extractSearchableBody(body: string, htmlBody: string): string {
+  if (body.trim()) return body;
+
+  return htmlBody
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,9 +3,12 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('api', {
   openMboxFile: () => ipcRenderer.invoke('open-mbox-file'),
   readMbox: (filePaths: string[]) => ipcRenderer.invoke('read-mbox', filePaths),
+  getSearchStatus: () => ipcRenderer.invoke('get-search-status'),
   getEmailDetail: (id: string) => ipcRenderer.invoke('get-email-detail', id),
   searchEmails: (params: unknown) => ipcRenderer.invoke('search-emails', params),
   saveAttachment: (data: unknown) => ipcRenderer.invoke('save-attachment', data),
   onLoadProgress: (cb: (data: unknown) => void) => ipcRenderer.on('load-progress', (_event, data) => cb(data)),
   offLoadProgress: () => ipcRenderer.removeAllListeners('load-progress'),
+  onSearchStatus: (cb: (data: unknown) => void) => ipcRenderer.on('search-status', (_event, data) => cb(data)),
+  offSearchStatus: () => ipcRenderer.removeAllListeners('search-status'),
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,11 +10,13 @@ export default function App() {
   const {
     phase, fileName, loadProgress,
     displayedEmails, totalMatched, totalCount,
+    searchStatus,
     query, sortOrder, excludeUnknown,
     selectedIndex, currentMeta, currentDetail,
     viewMode, setViewMode,
     openFile,
-    handleQueryChange, handleExcludeUnknownChange, handleSortToggle,
+    handleQueryChange, handleQueryKeyDown, handleQueryCompositionStart, handleQueryCompositionEnd,
+    handleExcludeUnknownChange, handleSortToggle,
     selectEmail, handleLoadMore,
   } = useMailbox();
   const [theme, setTheme] = useState<ThemeMode>(() => getStoredTheme(window.localStorage));
@@ -41,7 +43,11 @@ export default function App() {
         disabled={!isListVisible}
         totalMatched={totalMatched}
         totalCount={totalCount}
+        searchStatus={searchStatus}
         onQueryChange={handleQueryChange}
+        onQueryKeyDown={handleQueryKeyDown}
+        onQueryCompositionStart={handleQueryCompositionStart}
+        onQueryCompositionEnd={handleQueryCompositionEnd}
         onExcludeUnknownChange={handleExcludeUnknownChange}
         onSortToggle={handleSortToggle}
       />
@@ -51,6 +57,7 @@ export default function App() {
           selectedIndex={selectedIndex}
           totalMatched={totalMatched}
           query={query}
+          searchStatus={searchStatus}
           isVisible={isListVisible}
           hasMore={displayedEmails.length < totalMatched}
           onSelect={selectEmail}

--- a/src/renderer/EmailList.tsx
+++ b/src/renderer/EmailList.tsx
@@ -1,3 +1,4 @@
+import { SearchStatus } from '../searchStatus';
 import { EmailMeta } from './types';
 import { formatDate, highlight } from './utils';
 
@@ -6,6 +7,7 @@ interface Props {
   selectedIndex: number | null;
   totalMatched: number;
   query: string;
+  searchStatus: SearchStatus;
   isVisible: boolean;
   hasMore: boolean;
   onSelect: (index: number) => void;
@@ -13,7 +15,7 @@ interface Props {
 }
 
 export default function EmailList({
-  emails, selectedIndex, totalMatched, query,
+  emails, selectedIndex, totalMatched, query, searchStatus,
   isVisible, hasMore, onSelect, onLoadMore,
 }: Props) {
   return (
@@ -24,7 +26,9 @@ export default function EmailList({
         </div>
       )}
       {isVisible && totalMatched === 0 && (
-        <div id="email-list-empty">該当するメールがありません</div>
+        <div id="email-list-empty">
+          {getEmptyMessage(query, searchStatus)}
+        </div>
       )}
       {isVisible && emails.map((em, i) => (
         <div
@@ -55,4 +59,13 @@ export default function EmailList({
       )}
     </div>
   );
+}
+
+function getEmptyMessage(query: string, searchStatus: SearchStatus): string {
+  if (!query.trim()) return '該当するメールがありません';
+  if (searchStatus.phase === 'indexing') return '検索 index を構築中です';
+  if (searchStatus.phase === 'searching') return '自然言語検索を実行中です';
+  if (searchStatus.phase === 'searched') return `自然言語検索のヒットは 0 件です`;
+  if (searchStatus.phase === 'error') return searchStatus.message;
+  return '該当するメールがありません';
 }

--- a/src/renderer/SearchBar.tsx
+++ b/src/renderer/SearchBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { SearchStatus, describeSearchStatus } from '../searchStatus';
+
 interface Props {
   query: string;
   sortOrder: 'asc' | 'desc';
@@ -7,15 +9,20 @@ interface Props {
   disabled: boolean;
   totalMatched: number;
   totalCount: number;
+  searchStatus: SearchStatus;
   onQueryChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onQueryKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onQueryCompositionStart: () => void;
+  onQueryCompositionEnd: () => void;
   onExcludeUnknownChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSortToggle: () => void;
 }
 
 export default function SearchBar({
   query, sortOrder, excludeUnknown, disabled,
-  totalMatched, totalCount,
-  onQueryChange, onExcludeUnknownChange, onSortToggle,
+  totalMatched, totalCount, searchStatus,
+  onQueryChange, onQueryKeyDown, onQueryCompositionStart, onQueryCompositionEnd,
+  onExcludeUnknownChange, onSortToggle,
 }: Props) {
   return (
     <div id="search-bar">
@@ -26,6 +33,9 @@ export default function SearchBar({
         disabled={disabled}
         value={query}
         onChange={onQueryChange}
+        onKeyDown={onQueryKeyDown}
+        onCompositionStart={onQueryCompositionStart}
+        onCompositionEnd={onQueryCompositionEnd}
       />
       <label id="filter-unknown-label">
         <input
@@ -45,6 +55,9 @@ export default function SearchBar({
       </button>
       <span id="mail-count">
         {!disabled ? `${totalMatched} / ${totalCount} 件` : '—'}
+      </span>
+      <span id="search-status">
+        {describeSearchStatus(searchStatus)}
       </span>
     </div>
   );

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -1,3 +1,5 @@
+import { SearchStatus } from '../searchStatus';
+
 export interface EmailMeta {
   id: string;
   from: string;
@@ -28,6 +30,7 @@ declare global {
     api: {
       openMboxFile: () => Promise<string[] | null>;
       readMbox: (filePaths: string[]) => Promise<{ total?: number; error?: string }>;
+      getSearchStatus: () => Promise<SearchStatus>;
       getEmailDetail: (id: string) => Promise<EmailDetail>;
       searchEmails: (params: {
         query: string;
@@ -39,6 +42,8 @@ declare global {
       saveAttachment: (data: { filename: string; data: string }) => Promise<string>;
       onLoadProgress: (cb: (data: { percent: number; count: number }) => void) => void;
       offLoadProgress: () => void;
+      onSearchStatus: (cb: (data: SearchStatus) => void) => void;
+      offSearchStatus: () => void;
     };
   }
 }

--- a/src/renderer/useMailbox.ts
+++ b/src/renderer/useMailbox.ts
@@ -1,5 +1,7 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { Phase, EmailMeta, EmailDetail } from './types';
+import { shouldSubmitSearch } from '../searchInputBehavior';
+import { SearchStatus } from '../searchStatus';
 
 const PAGE_SIZE = 100;
 
@@ -11,6 +13,7 @@ export function useMailbox() {
   const [displayedEmails, setDisplayedEmails] = useState<EmailMeta[]>([]);
   const [totalMatched, setTotalMatched] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
+  const [searchStatus, setSearchStatus] = useState<SearchStatus>({ phase: 'idle' });
 
   const [query, setQuery] = useState('');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
@@ -21,7 +24,7 @@ export function useMailbox() {
   const [currentDetail, setCurrentDetail] = useState<EmailDetail | null>(null);
   const [viewMode, setViewMode] = useState<'html' | 'plain'>('html');
 
-  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isComposingRef = useRef(false);
 
   const loadPage = useCallback(async (offset: number, opts: {
     q: string;
@@ -38,6 +41,20 @@ export function useMailbox() {
     });
     setTotalMatched(result.total);
     setDisplayedEmails(offset === 0 ? result.emails : opts.prev.concat(result.emails));
+  }, []);
+
+  React.useEffect(() => {
+    window.api.onSearchStatus(status => {
+      setSearchStatus(status);
+    });
+
+    void window.api.getSearchStatus().then(status => {
+      setSearchStatus(status);
+    });
+
+    return () => {
+      window.api.offSearchStatus();
+    };
   }, []);
 
   const openFile = useCallback(async () => {
@@ -65,6 +82,7 @@ export function useMailbox() {
 
     setTotalCount(result.total ?? 0);
     setQuery('');
+    setSearchStatus({ phase: 'idle' });
     setSelectedIndex(null);
     setCurrentMeta(null);
     setCurrentDetail(null);
@@ -82,23 +100,36 @@ export function useMailbox() {
   }, [phase, loadPage]);
 
   const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const q = e.target.value;
-    setQuery(q);
-    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    searchTimerRef.current = setTimeout(() => runSearch(q, sortOrder, excludeUnknown), 200);
-  }, [sortOrder, excludeUnknown, runSearch]);
+    setQuery(e.target.value);
+  }, []);
+
+  const handleQueryKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    const nativeEvent = e.nativeEvent as KeyboardEvent;
+    const isComposing = isComposingRef.current || nativeEvent.isComposing;
+    if (!shouldSubmitSearch(e.key, isComposing)) return;
+
+    e.preventDefault();
+    void runSearch(query, sortOrder, excludeUnknown);
+  }, [query, sortOrder, excludeUnknown, runSearch]);
+
+  const handleQueryCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleQueryCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+  }, []);
 
   const handleExcludeUnknownChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const eu = e.target.checked;
     setExcludeUnknown(eu);
-    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
-    runSearch(query, sortOrder, eu);
+    void runSearch(query, sortOrder, eu);
   }, [query, sortOrder, runSearch]);
 
   const handleSortToggle = useCallback(() => {
     const so = sortOrder === 'desc' ? 'asc' : 'desc';
     setSortOrder(so);
-    runSearch(query, so, excludeUnknown);
+    void runSearch(query, so, excludeUnknown);
   }, [sortOrder, query, excludeUnknown, runSearch]);
 
   const selectEmail = useCallback(async (index: number) => {
@@ -125,6 +156,7 @@ export function useMailbox() {
     displayedEmails,
     totalMatched,
     totalCount,
+    searchStatus,
     query,
     sortOrder,
     excludeUnknown,
@@ -136,6 +168,9 @@ export function useMailbox() {
     // handlers
     openFile,
     handleQueryChange,
+    handleQueryKeyDown,
+    handleQueryCompositionStart,
+    handleQueryCompositionEnd,
     handleExcludeUnknownChange,
     handleSortToggle,
     selectEmail,

--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -15,6 +15,10 @@ export interface SearchResult {
 
 export type SearchTokenizer = (text: string) => Promise<string[]>;
 
+interface BuildSearchIndexOptions {
+  onProgress?: (indexed: number, total: number) => void;
+}
+
 export interface SearchRunner {
   search(query: string): Promise<SearchResult[]>;
 }
@@ -67,6 +71,7 @@ const TOKENIZE_CHUNK_SIZE = 100;
 export async function buildSearchIndex(
   docs: SearchDocument[],
   tokenizer: SearchTokenizer,
+  options: BuildSearchIndexOptions = {},
 ): Promise<SearchIndex> {
   const miniSearch = new MiniSearch<IndexedSearchDocument>({
     fields: [...INDEX_FIELDS],
@@ -75,15 +80,23 @@ export async function buildSearchIndex(
     processTerm: term => term,
   });
 
+  options.onProgress?.(0, docs.length);
+
   for (let i = 0; i < docs.length; i += TOKENIZE_CHUNK_SIZE) {
     const chunk = docs.slice(i, i + TOKENIZE_CHUNK_SIZE);
-    const indexedChunk = await Promise.all(chunk.map(async doc => ({
-      ...doc,
-      fromTerms: (await tokenizer(doc.from)).join(' '),
-      toTerms: (await tokenizer(doc.to)).join(' '),
-      subjectTerms: (await tokenizer(doc.subject)).join(' '),
-      bodyTerms: (await tokenizer(doc.body)).join(' '),
-    })));
+    const indexedChunk: IndexedSearchDocument[] = [];
+
+    for (const [chunkIndex, doc] of chunk.entries()) {
+      indexedChunk.push({
+        ...doc,
+        fromTerms: (await tokenizer(doc.from)).join(' '),
+        toTerms: (await tokenizer(doc.to)).join(' '),
+        subjectTerms: (await tokenizer(doc.subject)).join(' '),
+        bodyTerms: (await tokenizer(doc.body)).join(' '),
+      });
+      options.onProgress?.(Math.min(i + chunkIndex + 1, docs.length), docs.length);
+    }
+
     miniSearch.addAll(indexedChunk);
   }
 

--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -61,6 +61,9 @@ export class SearchIndex implements SearchRunner {
   }
 }
 
+// 一度に処理するドキュメント数。全件並列だとメモリ/CPUを大量消費するためチャンク分割する
+const TOKENIZE_CHUNK_SIZE = 100;
+
 export async function buildSearchIndex(
   docs: SearchDocument[],
   tokenizer: SearchTokenizer,
@@ -72,14 +75,17 @@ export async function buildSearchIndex(
     processTerm: term => term,
   });
 
-  const indexedDocs = await Promise.all(docs.map(async doc => ({
-    ...doc,
-    fromTerms: (await tokenizer(doc.from)).join(' '),
-    toTerms: (await tokenizer(doc.to)).join(' '),
-    subjectTerms: (await tokenizer(doc.subject)).join(' '),
-    bodyTerms: (await tokenizer(doc.body)).join(' '),
-  })));
+  for (let i = 0; i < docs.length; i += TOKENIZE_CHUNK_SIZE) {
+    const chunk = docs.slice(i, i + TOKENIZE_CHUNK_SIZE);
+    const indexedChunk = await Promise.all(chunk.map(async doc => ({
+      ...doc,
+      fromTerms: (await tokenizer(doc.from)).join(' '),
+      toTerms: (await tokenizer(doc.to)).join(' '),
+      subjectTerms: (await tokenizer(doc.subject)).join(' '),
+      bodyTerms: (await tokenizer(doc.body)).join(' '),
+    })));
+    miniSearch.addAll(indexedChunk);
+  }
 
-  miniSearch.addAll(indexedDocs);
   return new SearchIndex(miniSearch, tokenizer);
 }

--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -1,0 +1,81 @@
+import MiniSearch from 'minisearch';
+
+export interface SearchDocument {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export interface SearchResult {
+  id: string;
+  score: number;
+}
+
+export type SearchTokenizer = (text: string) => Promise<string[]>;
+
+interface IndexedSearchDocument {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  fromTerms: string;
+  toTerms: string;
+  subjectTerms: string;
+  bodyTerms: string;
+}
+
+const INDEX_FIELDS = ['fromTerms', 'toTerms', 'subjectTerms', 'bodyTerms'] as const;
+
+export class SearchIndex {
+  constructor(
+    private readonly miniSearch: MiniSearch<IndexedSearchDocument>,
+    private readonly tokenizer: SearchTokenizer,
+  ) {}
+
+  async search(query: string): Promise<SearchResult[]> {
+    const terms = await this.tokenizer(query);
+    if (terms.length === 0) return [];
+
+    return this.miniSearch.search(terms.join(' '), {
+      combineWith: 'AND',
+      prefix: (term, index) => index === terms.length - 1 && term.length >= 2,
+      fuzzy: (term) => term.length >= 4 ? 0.2 : false,
+      boost: {
+        subjectTerms: 5,
+        fromTerms: 3,
+        toTerms: 2,
+        bodyTerms: 1,
+      },
+      tokenize: text => text.split(' ').filter(Boolean),
+    }).map(result => ({
+      id: String(result.id),
+      score: result.score,
+    }));
+  }
+}
+
+export async function buildSearchIndex(
+  docs: SearchDocument[],
+  tokenizer: SearchTokenizer,
+): Promise<SearchIndex> {
+  const miniSearch = new MiniSearch<IndexedSearchDocument>({
+    fields: [...INDEX_FIELDS],
+    storeFields: ['id'],
+    tokenize: text => text.split(' ').filter(Boolean),
+    processTerm: term => term,
+  });
+
+  const indexedDocs = await Promise.all(docs.map(async doc => ({
+    ...doc,
+    fromTerms: (await tokenizer(doc.from)).join(' '),
+    toTerms: (await tokenizer(doc.to)).join(' '),
+    subjectTerms: (await tokenizer(doc.subject)).join(' '),
+    bodyTerms: (await tokenizer(doc.body)).join(' '),
+  })));
+
+  miniSearch.addAll(indexedDocs);
+  return new SearchIndex(miniSearch, tokenizer);
+}

--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -1,4 +1,5 @@
 import MiniSearch from 'minisearch';
+import { normalizeSearchText } from './searchTokenizer';
 
 export interface SearchDocument {
   id: string;
@@ -81,6 +82,7 @@ export async function buildSearchIndex(
   });
 
   options.onProgress?.(0, docs.length);
+  const tokenCache = new Map<string, Promise<string[]>>();
 
   for (let i = 0; i < docs.length; i += TOKENIZE_CHUNK_SIZE) {
     const chunk = docs.slice(i, i + TOKENIZE_CHUNK_SIZE);
@@ -89,10 +91,10 @@ export async function buildSearchIndex(
     for (const [chunkIndex, doc] of chunk.entries()) {
       indexedChunk.push({
         ...doc,
-        fromTerms: (await tokenizer(doc.from)).join(' '),
-        toTerms: (await tokenizer(doc.to)).join(' '),
-        subjectTerms: (await tokenizer(doc.subject)).join(' '),
-        bodyTerms: (await tokenizer(doc.body)).join(' '),
+        fromTerms: tokenizeAddressField(doc.from).join(' '),
+        toTerms: tokenizeAddressField(doc.to).join(' '),
+        subjectTerms: (await cachedTokenize(doc.subject, tokenizer, tokenCache)).join(' '),
+        bodyTerms: (await cachedTokenize(doc.body, tokenizer, tokenCache)).join(' '),
       });
       options.onProgress?.(Math.min(i + chunkIndex + 1, docs.length), docs.length);
     }
@@ -101,4 +103,22 @@ export async function buildSearchIndex(
   }
 
   return new SearchIndex(miniSearch, tokenizer);
+}
+
+function tokenizeAddressField(text: string): string[] {
+  return normalizeSearchText(text).split(' ').filter(Boolean);
+}
+
+async function cachedTokenize(
+  text: string,
+  tokenizer: SearchTokenizer,
+  cache: Map<string, Promise<string[]>>,
+): Promise<string[]> {
+  const normalized = text.trim();
+  const cached = cache.get(normalized);
+  if (cached) return cached;
+
+  const promise = tokenizer(text);
+  cache.set(normalized, promise);
+  return promise;
 }

--- a/src/searchEngine.ts
+++ b/src/searchEngine.ts
@@ -15,6 +15,10 @@ export interface SearchResult {
 
 export type SearchTokenizer = (text: string) => Promise<string[]>;
 
+export interface SearchRunner {
+  search(query: string): Promise<SearchResult[]>;
+}
+
 interface IndexedSearchDocument {
   id: string;
   from: string;
@@ -29,7 +33,7 @@ interface IndexedSearchDocument {
 
 const INDEX_FIELDS = ['fromTerms', 'toTerms', 'subjectTerms', 'bodyTerms'] as const;
 
-export class SearchIndex {
+export class SearchIndex implements SearchRunner {
   constructor(
     private readonly miniSearch: MiniSearch<IndexedSearchDocument>,
     private readonly tokenizer: SearchTokenizer,

--- a/src/searchIndexManager.ts
+++ b/src/searchIndexManager.ts
@@ -1,0 +1,93 @@
+import { buildSearchIndex, SearchDocument, SearchResult, SearchRunner, SearchTokenizer } from './searchEngine';
+import { SearchStatus } from './searchStatus';
+
+interface SearchIndexManagerOptions {
+  tokenizer: SearchTokenizer;
+  buildIndex?: (
+    docs: SearchDocument[],
+    tokenizer: SearchTokenizer,
+    onProgress?: (indexed: number, total: number) => void,
+  ) => Promise<SearchRunner>;
+  onStatusChange?: (status: SearchStatus) => void;
+}
+
+export class SearchIndexManager {
+  private index: SearchRunner | null = null;
+  private buildPromise: Promise<SearchRunner> | null = null;
+  private generation = 0;
+  private totalDocs = 0;
+
+  constructor(
+    private readonly options: SearchIndexManagerOptions,
+  ) {}
+
+  replaceAll(docs: SearchDocument[]): void {
+    const currentGeneration = ++this.generation;
+    this.index = null;
+    this.totalDocs = docs.length;
+    this.options.onStatusChange?.({ phase: 'indexing', indexed: 0, total: docs.length });
+    this.buildPromise = this.options.buildIndex
+      ? this.options.buildIndex(
+        [...docs],
+        this.options.tokenizer,
+        (indexed, total) => {
+          if (this.generation === currentGeneration) {
+            this.options.onStatusChange?.({ phase: 'indexing', indexed, total });
+          }
+        },
+      )
+      : buildSearchIndex(
+        [...docs],
+        this.options.tokenizer,
+        {
+          onProgress: (indexed, total) => {
+            if (this.generation === currentGeneration) {
+              this.options.onStatusChange?.({ phase: 'indexing', indexed, total });
+            }
+          },
+        },
+      );
+
+    this.buildPromise = this.buildPromise.then(createdIndex => {
+      if (this.generation === currentGeneration) {
+        this.index = createdIndex;
+        this.options.onStatusChange?.({ phase: 'ready', total: docs.length });
+      }
+      return createdIndex;
+    }).finally(() => {
+      if (this.generation === currentGeneration) {
+        this.buildPromise = null;
+      }
+    });
+  }
+
+  reset(): void {
+    this.generation += 1;
+    this.index = null;
+    this.buildPromise = null;
+    this.totalDocs = 0;
+    this.options.onStatusChange?.({ phase: 'idle' });
+  }
+
+  async search(query: string): Promise<SearchResult[]> {
+    const currentGeneration = this.generation;
+    const pendingBuild = this.buildPromise;
+
+    if (pendingBuild) {
+      try {
+        await pendingBuild;
+      } catch {
+        if (currentGeneration !== this.generation || !this.index) return [];
+        throw new Error('search index build failed');
+      }
+    }
+
+    if (currentGeneration !== this.generation || !this.index) return [];
+    this.options.onStatusChange?.({ phase: 'searching', query, total: this.totalDocs });
+    const results = await this.index.search(query);
+    if (currentGeneration === this.generation) {
+      this.options.onStatusChange?.({ phase: 'searched', query, hitCount: results.length, total: this.totalDocs });
+    }
+    return results;
+  }
+}

--- a/src/searchInputBehavior.ts
+++ b/src/searchInputBehavior.ts
@@ -1,0 +1,3 @@
+export function shouldSubmitSearch(key: string, isComposing: boolean): boolean {
+  return key === 'Enter' && !isComposing;
+}

--- a/src/searchStatus.ts
+++ b/src/searchStatus.ts
@@ -1,0 +1,24 @@
+export type SearchStatus =
+  | { phase: 'idle' }
+  | { phase: 'indexing'; indexed: number; total: number }
+  | { phase: 'ready'; total: number }
+  | { phase: 'searching'; query: string; total: number }
+  | { phase: 'searched'; query: string; hitCount: number; total: number }
+  | { phase: 'error'; message: string };
+
+export function describeSearchStatus(status: SearchStatus): string {
+  switch (status.phase) {
+    case 'idle':
+      return '検索 index 未構築';
+    case 'indexing':
+      return `検索 index 構築中 ${status.indexed} / ${status.total}`;
+    case 'ready':
+      return `検索 index 準備完了 ${status.total} 件`;
+    case 'searching':
+      return `検索中: ${status.query}`;
+    case 'searched':
+      return `自然言語検索 ${status.hitCount} / ${status.total} 件`;
+    case 'error':
+      return `検索エラー: ${status.message}`;
+  }
+}

--- a/src/searchTokenizer.ts
+++ b/src/searchTokenizer.ts
@@ -1,0 +1,43 @@
+import { KuromojiToken, tokenize } from 'kuromojin';
+
+const STOP_POS = new Set(['記号', '助詞', '助動詞']);
+
+export async function tokenizeJapaneseText(text: string): Promise<string[]> {
+  const normalized = normalizeSearchText(text);
+  if (!normalized) return [];
+
+  try {
+    const tokens = await tokenize(normalized);
+    return flattenKuromojiTokens(tokens);
+  } catch {
+    return normalized.split(' ').filter(Boolean);
+  }
+}
+
+export function normalizeSearchText(text: string): string {
+  return text
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/[_/\\|()[\]{}<>"'`~!@#$%^&*=+?,.:;-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function flattenKuromojiTokens(tokens: Readonly<Readonly<KuromojiToken>[]>): string[] {
+  const terms: string[] = [];
+
+  for (const token of tokens) {
+    if (STOP_POS.has(token.pos)) continue;
+
+    const surface = normalizeSearchText(token.surface_form);
+    if (surface) terms.push(surface);
+
+    const basic = normalizeSearchText(token.basic_form);
+    if (basic && basic !== '*' && basic !== surface) {
+      terms.push(basic);
+    }
+  }
+
+  return terms;
+}

--- a/src/searchTokenizer.ts
+++ b/src/searchTokenizer.ts
@@ -9,7 +9,9 @@ export async function tokenizeJapaneseText(text: string): Promise<string[]> {
   try {
     const tokens = await tokenize(normalized);
     return flattenKuromojiTokens(tokens);
-  } catch {
+  } catch (err) {
+    // kuromoji の辞書ロード失敗などはサイレントに埋もれないようログに残す
+    console.error('[searchTokenizer] kuromoji tokenize failed, falling back to space split:', err);
     return normalized.split(' ').filter(Boolean);
   }
 }

--- a/src/searchWorker.ts
+++ b/src/searchWorker.ts
@@ -1,0 +1,54 @@
+import { parentPort } from 'worker_threads';
+import { tokenizeJapaneseText } from './searchTokenizer';
+import { SearchIndexManager } from './searchIndexManager';
+import { SearchWorkerRequest, SearchWorkerResponse } from './searchWorkerProtocol';
+
+const manager = new SearchIndexManager({
+  tokenizer: tokenizeJapaneseText,
+  onStatusChange: status => {
+    respond({ kind: 'status', status });
+  },
+});
+
+if (!parentPort) {
+  throw new Error('searchWorker requires parentPort');
+}
+
+parentPort.on('message', (message: SearchWorkerRequest) => {
+  void handleMessage(message);
+});
+
+async function handleMessage(message: SearchWorkerRequest): Promise<void> {
+  try {
+    if (message.type === 'reset') {
+      manager.reset();
+      respond({ kind: 'response', id: message.id, ok: true, result: null });
+      return;
+    }
+
+    if (message.type === 'replaceAll') {
+      manager.replaceAll(message.docs || []);
+      respond({ kind: 'response', id: message.id, ok: true, result: null });
+      return;
+    }
+
+    if (message.type === 'search') {
+      const results = await manager.search(message.query || '');
+      respond({ kind: 'response', id: message.id, ok: true, result: results });
+      return;
+    }
+
+    respond({ kind: 'response', id: message.id, ok: false, error: `Unknown message type: ${String(message.type)}` });
+  } catch (err) {
+    respond({
+      kind: 'response',
+      id: message.id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function respond(message: SearchWorkerResponse): void {
+  parentPort!.postMessage(message);
+}

--- a/src/searchWorkerProtocol.ts
+++ b/src/searchWorkerProtocol.ts
@@ -1,0 +1,33 @@
+import { SearchDocument, SearchResult } from './searchEngine';
+import { SearchStatus } from './searchStatus';
+
+export interface SearchWorkerRequest {
+  id: number;
+  type: 'replaceAll' | 'reset' | 'search';
+  docs?: SearchDocument[];
+  query?: string;
+}
+
+export interface SearchWorkerSuccessResponse {
+  kind: 'response';
+  id: number;
+  ok: true;
+  result: null | SearchResult[];
+}
+
+export interface SearchWorkerErrorResponse {
+  kind: 'response';
+  id: number;
+  ok: false;
+  error: string;
+}
+
+export interface SearchWorkerStatusEvent {
+  kind: 'status';
+  status: SearchStatus;
+}
+
+export type SearchWorkerResponse =
+  | SearchWorkerSuccessResponse
+  | SearchWorkerErrorResponse
+  | SearchWorkerStatusEvent;

--- a/src/searchableBody.ts
+++ b/src/searchableBody.ts
@@ -1,0 +1,15 @@
+const MAX_SEARCHABLE_BODY_LENGTH = 4000;
+const LONG_BINARYISH_RUN = /\b[A-Za-z0-9+/=]{80,}\b/g;
+
+export function extractSearchableBody(body: string, htmlBody: string): string {
+  const source = body.trim() ? body : htmlBody
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ');
+
+  return source
+    .replace(LONG_BINARYISH_RUN, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_SEARCHABLE_BODY_LENGTH);
+}

--- a/src/searchableBody.ts
+++ b/src/searchableBody.ts
@@ -1,4 +1,4 @@
-const MAX_SEARCHABLE_BODY_LENGTH = 4000;
+const MAX_SEARCHABLE_BODY_LENGTH = 2000;
 const LONG_BINARYISH_RUN = /\b[A-Za-z0-9+/=]{80,}\b/g;
 
 export function extractSearchableBody(body: string, htmlBody: string): string {


### PR DESCRIPTION
## Summary
- MiniSearch ベースのローカル検索インデックスをメタデータ・本文に対して構築
- kuromoji/kuromojin で日本語クエリとメール本文をトークン化してインデックス化
- 既存の from/to/date フィルタを維持しつつ、自由文検索の関連度スコアによるランキングに対応

## 変更内容
- `src/searchEngine.ts`: MiniSearch ラッパー。フィールドごとのブースト（件名×5、from×3、to×2、本文×1）でスコアリング
- `src/lazySearchIndex.ts`: 初回検索まで index 構築を遅延させる LazySearchIndex
- `src/searchTokenizer.ts`: kuromojin による日本語トークナイザー（ストップ品詞除去・NFKC正規化）
- `src/main.ts`: `emailSearchCache`（文字列マップ）を `emailSearchIndex` に置き換え。検索結果をスコア順→日付順で並べ替え
- テスト追加: `lazySearchIndex.test.ts`, `searchEngine.test.ts`

## 概要
（記入してください）

## テスト項目
- [ ] 日本語キーワードで本文・件名・from/to が検索できること
- [ ] 検索結果が関連度スコア順に並ぶこと
- [ ] フィルタ（from/to/since/until）と自由文検索の組み合わせが動作すること
- [ ] 複数ファイル読み込み後に検索が正常に動作すること